### PR TITLE
Remove range syntax

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,18 +97,18 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
-            <version>[${clojure.version}]</version>
+            <version>${clojure.version}</version>
             <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>core.specs.alpha</artifactId>
-            <version>[${core.specs.alpha.version}]</version>
+            <version>${core.specs.alpha.version}</version>
         </dependency>
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>spec.alpha</artifactId>
-            <version>[${spec.alpha.version}]</version>
+            <version>${spec.alpha.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The use of range syntax like this is throwing warnings in Clojure projects that use `lein`:

```clj
WARNING!!! version ranges found for:
[com.theoryinpractise/clojure.osgi "1.9.0-2"] -> [org.clojure/clojure "[1.9.0,1.9.0]"]
Consider using [com.theoryinpractise/clojure.osgi "1.9.0-2" :exclusions [org.clojure/clojure]].
```

Not sure of the intended/planned use for the ranged values, since right now only one value is being used ...